### PR TITLE
Test methods changed

### DIFF
--- a/Tests/UnitTest/EditorTests.cs
+++ b/Tests/UnitTest/EditorTests.cs
@@ -19,7 +19,7 @@ namespace MatrixRotator.Tests
         }
 
         [TestMethod]
-        public void LoadTest()
+        public void Load()
         {
             int rowCount = 4;
             int columnCount = 3;
@@ -49,7 +49,7 @@ namespace MatrixRotator.Tests
         }
 
         [TestMethod]
-        public void SaveTest()
+        public void Save()
         {
             int rowCount = 4;
             int columnCount = 3;
@@ -83,7 +83,7 @@ namespace MatrixRotator.Tests
         }
 
         [TestMethod]
-        public void RotateTest()
+        public void Rotate()
         {
             int rowCount = 4;
             int columnCount = 3;


### PR DESCRIPTION
This pull request includes minor changes to the `Tests/UnitTest/EditorTests.cs` file, where the test method names have been simplified by removing the "Test" suffix.

* Simplified test method names:
  * `public void LoadTest()` to `public void Load()`
  * `public void SaveTest()` to `public void Save()`
  * `public void RotateTest()` to `public void Rotate()`